### PR TITLE
new architecture for da covariate shift

### DIFF
--- a/src/decision_tree_classifier/decision_tree_classifier.py
+++ b/src/decision_tree_classifier/decision_tree_classifier.py
@@ -55,14 +55,17 @@ class DecisionTreeClassifier(object):
             return None, 0
         # base case 3: all y is the same in this group
         if self.all_same(y):
-            return {'type': 'leaf', 'val': y.iloc[0], 'tot': leny, 'dist': y.value_counts(sort=False) / leny}, 0
+            return {'type': 'leaf',
+                    'val': y.iloc[0], 'tot': leny, 'dist': y.value_counts(sort=False) / leny}, 0
         # base case 4: max depth reached
         if depth >= self.max_depth:
-            return {'type': 'leaf', 'val': stats.mode(y).mode[0], 'tot': leny, 'dist': y.value_counts(sort=False) / leny}, 0
+            return {'type': 'leaf',
+                    'val': stats.mode(y).mode[0], 'tot': leny, 'dist': y.value_counts(sort=False) / leny}, 0
         # recursive case:
         col, cutoff, gain = self.find_best_split_of_all(X, y)  # find one split given an information gain
         if col is None:  # no split improves
-            return {'type': 'leaf', 'val': stats.mode(y).mode[0], 'tot': leny, 'dist': y.value_counts(sort=False) / leny}, 0
+            return {'type': 'leaf',
+                    'val': stats.mode(y).mode[0], 'tot': leny, 'dist': y.value_counts(sort=False) / leny}, 0
         if col in self.cat:  # split for cont. vars; all-but for cat. vars
             cond = X[col] == cutoff
         else:
@@ -72,7 +75,8 @@ class DecisionTreeClassifier(object):
         y_left = y[cond]    # left hand side data
         y_right = y[~cond]  # right hand side data
         print('split', col, gain, cutoff)
-        par_node = {'type': 'split', 'gain': gain, 'split_col': col, 'cutoff': cutoff, 'tot': leny, 'dist': y.value_counts(sort=False) / leny}  # save the information: distribution of y
+        par_node = {'type': 'split',
+                    'gain': gain, 'split_col': col, 'cutoff': cutoff, 'tot': leny, 'dist': y.value_counts(sort=False) / leny}  # save the information: distribution of y
 
         # track (sub)trees
         if depth > 0:
@@ -81,13 +85,14 @@ class DecisionTreeClassifier(object):
         self.curr_tree = self._store_subtree(par_node)
 
         # generate tree for the left hand side data
-        self.you_are_here = (depth + 1, 'lhs')
+        self.you_are_here = (depth + 1, col, cutoff, 'lhs')
         par_node['left'], dleft = self.build(X_left, y_left, depth + 1)
         # temp_l_tree, dleft = self.build(X_left, y_left, depth + 1) # todo check bcs order affects the recursive search
         # par_node['left'] = temp_l_tree
         # self.curr_tree['left'] = self._store_subtree(temp_l_tree)
+
         # generate tree for the right hand side data
-        self.you_are_here = (depth + 1, 'rhs')
+        self.you_are_here = (depth + 1, col, cutoff, 'rhs')
         par_node['right'], dright = self.build(X_right, y_right, depth + 1)
         # temp_r_tree, dright = self.build(X_right, y_right, depth + 1)
         # par_node['right'] = temp_r_tree
@@ -131,7 +136,7 @@ class DecisionTreeClassifier(object):
 
     def find_best_split_of_all(self, X: DataFrame, y: Series):
 
-        # you_are_here = (layer: int, att: str, side: str)
+        ### you_are_here = (layer: int, att: str, side: str)
         if self.running_da_tree:
             if self.you_are_here[0] == 0:
                 # root node
@@ -140,8 +145,16 @@ class DecisionTreeClassifier(object):
             else:
                 # all other nodes
                 # current_path = self.get_current_path() todo atm, assumes unconditional path
-                y_td = self.y_td.copy()  # todo
-                X_td = self.X_td.copy()
+                if self.you_are_here[1] in self.cat:
+                    cond = self.X_td[self.you_are_here[1]] == self.you_are_here[2]
+                else:
+                    cond = self.X_td[self.you_are_here[1]] < self.you_are_here[2]
+                if self.you_are_here[3] == 'lhs':
+                    y_td = self.y_td[cond].copy()
+                    X_td = self.X_td[cond].copy()
+                else:  # self.you_are_here[3] == 'rhs'
+                    y_td = self.y_td[~cond].copy()
+                    X_td = self.X_td[~cond].copy()
         else:
             y_td = None
             X_td = None

--- a/src/decision_tree_classifier/decision_tree_classifier.py
+++ b/src/decision_tree_classifier/decision_tree_classifier.py
@@ -34,8 +34,8 @@ class DecisionTreeClassifier(object):
         # domain adaptation params
         if X_td is not None:
             self.running_da_cov_shift = True
-        if X_td is not None and y_td is not None:
-            self.running_da_con_shift = True
+        # if X_td is not None and y_td is not None:  todo later?
+        #     self.running_da_con_shift = True
         self.alpha = alpha if alpha is not None else alpha
         self.X_td = X_td if X_td is not None else X_td
         self.y_td = y_td if y_td is not None else y_td
@@ -79,7 +79,7 @@ class DecisionTreeClassifier(object):
         par_node = {'type': 'split',
                     'gain': gain, 'split_col': col, 'cutoff': cutoff, 'tot': leny, 'dist': y.value_counts(sort=False) / leny}
 
-        # the beauty of recursion (?)
+        # the beauty of recursion (?) | delete print statements later
         prev_path = self._current_path.copy()
         print(prev_path)
         # generate tree for the left hand side data
@@ -98,80 +98,52 @@ class DecisionTreeClassifier(object):
 
         return par_node, max(dleft, dright) + 1
 
-    # # todo
-    # def _store_subtree(self, par_node: Dict):
-    #     if par_node is None:
-    #         print('no data in this group')
-    #         return None
-    #     else:
-    #         # return `split` info
-    #         if par_node['type'] == 'split':
-    #             if par_node['split_col'] in self.cat:
-    #                 l_rule = '== {cutoff}'.format(cutoff=par_node['cutoff'])
-    #                 r_rule = '!= {cutoff}'.format(cutoff=par_node['cutoff'])
-    #             else:
-    #                 l_rule = '< {cutoff}'.format(cutoff=par_node['cutoff'])
-    #                 r_rule = '>= {cutoff}'.format(cutoff=par_node['cutoff'])
-    #             sub_tree = {'type': par_node['type'],
-    #                         'split_col': par_node['split_col'],
-    #                         'cutoff': par_node['cutoff'],
-    #                         'lhs': l_rule, 'rhs': r_rule}
-    #         # return `leaf` info
-    #         else:
-    #             sub_tree = {'type': par_node['type']}
-    #     return sub_tree
-
-    # todo
-    # def _get_current_path(self):
-    #     current_path = []
-    #     while self.you_are_here[0] > 0:
-    #         prev_layer = self.you_are_here[0] - 1
-
     @staticmethod
     def all_same(items):
         return all(x == items.iloc[0] for x in items)
 
+    def get_target_weights(self, current_path: List[Tuple[str, object, str]], X: DataFrame) -> Dict:
+        target_weights = {}
+        if len(current_path) > 0:
+            print('provide conditional weights based on current path')  # use current_path TODO
+        else:
+            # you're at the root node
+            print('provide the unconditional weights')  # use current_path TODO
+        # use X to build a target_weights dictionary based on the domain source (?)
+        # e.g., target_weights[c] = prob[c] where c in X.columns and prob is from the target domain info
+        #   can have target_weights[c] = None
+
+        for c in X.columns:
+            target_weights[c] = None
+
+        return target_weights
+
     def find_best_split_of_all(self, X: DataFrame, y: Series):
 
-        if len(self._you_are_here) > 0:
-            print("you're at the {side} of {col}".format(side=self._you_are_here[2], col=self._you_are_here[0]))
-
-        # you_are_here = (att: str, cutoff, side: str) todo: function handle X_td as dataframe, list, etc...
-        if self.running_da_con_shift:
-            if len(self._you_are_here) == 1:
-                # root node
-                y_td = self.y_td.copy()
-                X_td = self.X_td.copy()
-            else:
-                print(self._you_are_here)
-                y_td = self.y_td.copy()
-                X_td = self.X_td.copy()
-
-                # all other nodes
-                # current_path = self.get_current_path() todo
-
-                # if self.you_are_here[1] in self.cat:
-                #     cond = self.X_td[self.you_are_here[1]] == self.you_are_here[2]
-                # else:
-                #     cond = self.X_td[self.you_are_here[1]] < self.you_are_here[2]
-                # if self.you_are_here[3] == 'lhs':
-                #     y_td = self.y_td[cond].copy()
-                #     X_td = self.X_td[cond].copy()
-                # else:  # self.you_are_here[3] == 'rhs'
-                #     y_td = self.y_td[~cond].copy()
-                #     X_td = self.X_td[~cond].copy()
+        if len(self._you_are_here) > 0:  # delete later
+            print("you're at the {side} hs of {col}".format(side=self._you_are_here[2], col=self._you_are_here[0]))
         else:
-            y_td = None
-            X_td = None
-        ###
+            print("root node")
+
+        if self.running_da_cov_shift:
+            target_weights = self.get_target_weights(self._current_path, X)
+        else:
+            target_weights = None
 
         best_gain = 0
         best_col = None
         best_cutoff = None
         for c in X.columns:
             is_cat = c in self.cat
-            if self.running_da_con_shift:
-                gain, cur_cutoff = self.da_find_best_split_attribute(X[c], y, is_cat, X_td[c], y_td, self.alpha)
+            # domain-adaptive information gain
+            if self.running_da_cov_shift:
+                # proceed with da if we have a target weight for att c given the current path
+                if target_weights[c] is not None:
+                    gain, cur_cutoff = self.da_find_best_split_attribute(X[c], y, is_cat, self.alpha, target_weights[c])
+                # otherwise: alpha=1.0 to use only source domain info; t_weight=0.0 to keep function arch
+                else:
+                    gain, cur_cutoff = self.da_find_best_split_attribute(X[c], y, is_cat, 1.0, 0.0)
+            # standard information gain
             else:
                 gain, cur_cutoff = self.find_best_split_attribute(X[c], y, is_cat)
             if gain > best_gain:
@@ -210,7 +182,7 @@ class DecisionTreeClassifier(object):
                 best_cutoff = value
         return best_gain, best_cutoff
 
-    def da_find_best_split_attribute(self, x: Series, y: Series, is_cat: bool, x_td: Series, y_td: Series, alpha: float):
+    def da_find_best_split_attribute_v0(self, x: Series, y: Series, is_cat: bool, x_td: Series, y_td: Series, alpha: float):
         best_gain = 0
         best_cutoff = None
         if is_cat:
@@ -218,7 +190,7 @@ class DecisionTreeClassifier(object):
         else:
             values = np.sort(x.unique())
         # get entropy H(T)
-        entropy_total = self.da_info(self.y_values, y, y_td, alpha)
+        entropy_total = self.da_info_v0(self.y_values, y, y_td, alpha)
         n_tot = len(x)
         for value in values:
             cond = x == value if is_cat else x < value
@@ -230,8 +202,38 @@ class DecisionTreeClassifier(object):
             if n_right < self.min_cases:
                 continue
             # get entropy H(T|A=a)
-            entropy_left = self.da_info(self.y_values, y[cond], y_td[cond_for_td], self.alpha)     # < value
-            entropy_right = self.da_info(self.y_values, y[~cond], y_td[~cond_for_td], self.alpha)  # >= value
+            entropy_left = self.da_info_v0(self.y_values, y[cond], y_td[cond_for_td], self.alpha)     # < value
+            entropy_right = self.da_info_v0(self.y_values, y[~cond], y_td[~cond_for_td], self.alpha)  # >= value
+            left_prop = n_left / n_tot
+            right_prop = 1 - left_prop
+            # Information Gain: H(T) - H(T|A=a)
+            gain = entropy_total - left_prop * entropy_left - right_prop * entropy_right
+            if gain > best_gain:
+                best_gain = gain
+                best_cutoff = value
+        return best_gain, best_cutoff
+
+    def da_find_best_split_attribute(self, x: Series, y: Series, is_cat: bool, alpha: float, t_weight: float):
+        best_gain = 0
+        best_cutoff = None
+        if is_cat:
+            values = x.unique()
+        else:
+            values = np.sort(x.unique())
+        # get entropy H(T)
+        entropy_total = self.da_info(y, t_weight, alpha)
+        n_tot = len(x)
+        for value in values:
+            cond = x == value if is_cat else x < value
+            n_left = sum(cond)
+            if n_left < self.min_cases:
+                continue
+            n_right = n_tot - n_left
+            if n_right < self.min_cases:
+                continue
+            # get entropy H(T|A=a) todo: do we update t_weight under A=a?
+            entropy_left = self.da_info(y[cond], t_weight, alpha)     # < value
+            entropy_right = self.da_info(y[~cond], t_weight, alpha)  # >= value
             left_prop = n_left / n_tot
             right_prop = 1 - left_prop
             # Information Gain: H(T) - H(T|A=a)
@@ -252,7 +254,8 @@ class DecisionTreeClassifier(object):
         return ent
 
     @staticmethod
-    def da_info(y_values: List[int], y_source: Series, y_target: Series, alpha: float):  # todo: da_info for X_td only
+    def da_info_v0(y_values: List[int], y_source: Series, y_target: Series, alpha: float):
+        # v0: requires y_s and y_t, expecting both to be pd.Series - the ideal case
         # source domain
         vc_s = y_source.value_counts()
         tot_s = len(y_source)
@@ -273,6 +276,17 @@ class DecisionTreeClassifier(object):
             da_prop = (alpha * prop_s + (1 - alpha) * prop_t)
             if da_prop > 0.0:
                 ent -= da_prop * math.log2(da_prop)
+        return ent
+
+    @staticmethod
+    def da_info(y_source: Series, p_target: float, alpha: float):
+        vc = y_source.value_counts()
+        tot = len(y_source)
+        ent = 0
+        for v in vc:
+            prop = v / tot
+            da_w = (alpha * prop + (1 - alpha) * p_target)
+            ent -= da_w * math.log2(prop)  # todo: or da_w goes in I() too?
         return ent
 
     def predict(self, X):

--- a/src/decision_tree_classifier/decision_tree_classifier.py
+++ b/src/decision_tree_classifier/decision_tree_classifier.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Fri Jun 25 11:24:42 2021
-implementtion of decision tree adapted from
-https://medium.com/@penggongting/implementing-decision-tree-from-scratch-in-python-c732e7c69aea
-@author: scott
-"""
-
 import numpy as np
 import math
 from scipy import stats
@@ -221,26 +213,6 @@ class DecisionTreeClassifier(object):
         else:
             return [cur_layer.get('val'), cur_layer.get('dist')]
 
-
-if __name__ == "__main__":
-    from sklearn.datasets import load_iris, load_boston
-    iris = load_iris()
-    # boston = load_boston()
-
-    from tools import *
-    from pprint import pprint
-
-    # X = iris.data
-    X = pd.DataFrame(iris.data, columns=iris.feature_names)
-    X['y'] = iris.target
-    y = X['y']
-    X = X[iris.feature_names]
-
-    X_train, X_test, y_train, y_test = split_data(X, y)
-
-    clf = DecisionTreeClassifier(max_depth=7, cat=['test', 'me'])
-    clf.fit(X_train, y_train)
-    pprint(clf.tree)
-    # create adjusted splitting criterion
-    predictions = clf.predict(X_test)
-    accuracy = print_scores(y_test, predictions['prediction'])
+#
+# EOF
+#

--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,7 @@ import pandas as pd
 import pickle
 import time
 
-
+# TODO: clean up file (main should only run a working example; load_ functions can go under tools or utils or data)
 start_time = time.time()
 
 

--- a/src/prototype_iris.py
+++ b/src/prototype_iris.py
@@ -13,7 +13,7 @@ X['y'] = iris.target
 y = X['y']
 X = X[iris.feature_names]
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.7, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=42)
 print(X_train.shape)
 print(X_test.shape)
 
@@ -22,7 +22,7 @@ target_df = X_test.copy()
 target_df['y'] = y_test.copy()
 target_df.reset_index(inplace=True, drop=True)
 
-# standard dt
+# # standard dt
 org_clf = DecisionTreeClassifier(max_depth=5)
 org_clf.fit(X_train, y_train)
 # pprint(org_clf.tree)
@@ -32,7 +32,7 @@ print(org_accuracy)
 
 # domain adapted dt (v1)
 da1_clf = DecisionTreeClassifier(max_depth=5)
-da1_clf.fit(X_train, y_train, alpha=0.75, X_target_domain=X_test, y_target_domain=y_test)
+da1_clf.fit(X_train, y_train, alpha=0.75, X_td=X_test, y_td=y_test)
 # pprint(da1_clf.tree)
 da1_pred = da1_clf.predict(X_test)
 da1_accuracy = print_scores(y_test, da1_pred['prediction'])
@@ -40,7 +40,7 @@ print(da1_accuracy)
 
 # domain adapted dt (v2)
 da2_clf = DecisionTreeClassifier(max_depth=5)
-da2_clf.fit(X_train, y_train, alpha=1.0, X_target_domain=X_test, y_target_domain=y_test)
+da2_clf.fit(X_train, y_train, alpha=1.0, X_td=X_test, y_td=y_test)
 # pprint(da2_clf.tree)
 da2_pred = da2_clf.predict(X_test)
 da2_accuracy = print_scores(y_test, da2_pred['prediction'])
@@ -48,12 +48,12 @@ print(da2_accuracy)
 
 # domain adapted dt (v3)
 da3_clf = DecisionTreeClassifier(max_depth=5)
-da3_clf.fit(X_train, y_train, alpha=0.0, X_target_domain=X_test, y_target_domain=y_test)
+da3_clf.fit(X_train, y_train, alpha=0.0, X_td=X_test, y_td=y_test)
 # pprint(da3_clf.tree)
 da3_pred = da3_clf.predict(X_test)
 da3_accuracy = print_scores(y_test, da3_pred['prediction'])
 
-print(org_accuracy)
+# print(org_accuracy)
 print(da1_accuracy)
 print(da2_accuracy)  # with alpha=1.0, it's the same as running the standard DT
 print(da3_accuracy)

--- a/src/prototype_iris.py
+++ b/src/prototype_iris.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import numpy as np
+from pprint import pprint
+from src.decision_tree_classifier.decision_tree_classifier import DecisionTreeClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.datasets import load_iris
+iris = load_iris()
+
+# iris as a data frame
+X = pd.DataFrame(iris.data, columns=iris.feature_names)
+X['y'] = iris.target
+y = X['y']
+X = X[iris.feature_names]
+
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
+
+# my "target domain"
+target_df = X_test.copy()
+target_df['y'] = y_test.copy()
+target_df.reset_index(inplace=True, drop=True)
+
+clf = DecisionTreeClassifier(max_depth=7, )
+clf.fit(X_train, y_train, cat_atts=['test', 'me'], alpha=0.7, X_target_domain=X_test, y_target_domain=y_test)
+pprint(clf.tree)
+
+
+# create adjusted splitting criterion
+# predictions = clf.predict(X_test)
+# accuracy = print_scores(y_test, predictions['prediction'])

--- a/src/prototype_iris.py
+++ b/src/prototype_iris.py
@@ -2,6 +2,7 @@ import pandas as pd
 import numpy as np
 from pprint import pprint
 from src.decision_tree_classifier.decision_tree_classifier import DecisionTreeClassifier
+from src.decision_tree_classifier.tools import *
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_iris
 iris = load_iris()
@@ -12,19 +13,47 @@ X['y'] = iris.target
 y = X['y']
 X = X[iris.feature_names]
 
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=42)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.7, random_state=42)
+print(X_train.shape)
+print(X_test.shape)
 
 # my "target domain"
 target_df = X_test.copy()
 target_df['y'] = y_test.copy()
 target_df.reset_index(inplace=True, drop=True)
 
-clf = DecisionTreeClassifier(max_depth=7, )
-# clf.fit(X_train, y_train, cat_atts=['test', 'me'])
-clf.fit(X_train, y_train, cat_atts=['test', 'me'], alpha=0.7, X_target_domain=X_test, y_target_domain=y_test)
-pprint(clf.tree)
+# standard dt
+org_clf = DecisionTreeClassifier(max_depth=5)
+org_clf.fit(X_train, y_train)
+# pprint(org_clf.tree)
+org_pred = org_clf.predict(X_test)
+org_accuracy = print_scores(y_test, org_pred['prediction'])
+print(org_accuracy)
 
+# domain adapted dt (v1)
+da1_clf = DecisionTreeClassifier(max_depth=5)
+da1_clf.fit(X_train, y_train, alpha=0.75, X_target_domain=X_test, y_target_domain=y_test)
+# pprint(da1_clf.tree)
+da1_pred = da1_clf.predict(X_test)
+da1_accuracy = print_scores(y_test, da1_pred['prediction'])
+print(da1_accuracy)
 
-# create adjusted splitting criterion
-# predictions = clf.predict(X_test)
-# accuracy = print_scores(y_test, predictions['prediction'])
+# domain adapted dt (v2)
+da2_clf = DecisionTreeClassifier(max_depth=5)
+da2_clf.fit(X_train, y_train, alpha=1.0, X_target_domain=X_test, y_target_domain=y_test)
+# pprint(da2_clf.tree)
+da2_pred = da2_clf.predict(X_test)
+da2_accuracy = print_scores(y_test, da2_pred['prediction'])
+print(da2_accuracy)
+
+# domain adapted dt (v3)
+da3_clf = DecisionTreeClassifier(max_depth=5)
+da3_clf.fit(X_train, y_train, alpha=0.0, X_target_domain=X_test, y_target_domain=y_test)
+# pprint(da3_clf.tree)
+da3_pred = da3_clf.predict(X_test)
+da3_accuracy = print_scores(y_test, da3_pred['prediction'])
+
+print(org_accuracy)
+print(da1_accuracy)
+print(da2_accuracy)  # with alpha=1.0, it's the same as running the standard DT
+print(da3_accuracy)

--- a/src/prototype_iris.py
+++ b/src/prototype_iris.py
@@ -20,6 +20,7 @@ target_df['y'] = y_test.copy()
 target_df.reset_index(inplace=True, drop=True)
 
 clf = DecisionTreeClassifier(max_depth=7, )
+# clf.fit(X_train, y_train, cat_atts=['test', 'me'])
 clf.fit(X_train, y_train, cat_atts=['test', 'me'], alpha=0.7, X_target_domain=X_test, y_target_domain=y_test)
 pprint(clf.tree)
 

--- a/src/prototype_iris.py
+++ b/src/prototype_iris.py
@@ -22,17 +22,19 @@ target_df = X_test.copy()
 target_df['y'] = y_test.copy()
 target_df.reset_index(inplace=True, drop=True)
 
+# current_path example: [('petal length (cm)', 3.0, 'right'), ('petal width (cm)', 1.8, 'left')]
+
 # # standard dt
-org_clf = DecisionTreeClassifier(max_depth=5)
-org_clf.fit(X_train, y_train)
-# pprint(org_clf.tree)
-org_pred = org_clf.predict(X_test)
-org_accuracy = print_scores(y_test, org_pred['prediction'])
-print(org_accuracy)
+# org_clf = DecisionTreeClassifier(max_depth=5)
+# org_clf.fit(X_train, y_train)
+# # pprint(org_clf.tree)
+# org_pred = org_clf.predict(X_test)
+# org_accuracy = print_scores(y_test, org_pred['prediction'])
+# print(org_accuracy)
 
 # domain adapted dt (v1)
 da1_clf = DecisionTreeClassifier(max_depth=5)
-da1_clf.fit(X_train, y_train, alpha=0.75, X_td=X_test, y_td=y_test)
+da1_clf.fit(X_train, y_train, alpha=0.75, X_td=X_test, )
 # pprint(da1_clf.tree)
 da1_pred = da1_clf.predict(X_test)
 da1_accuracy = print_scores(y_test, da1_pred['prediction'])

--- a/src/utils.py
+++ b/src/utils.py
@@ -59,6 +59,11 @@ def get_proportion_groupby(pop_data, group_column, threshold=None):
 # path will be col, split value, left or right, categorical true or false - over multiple splits
 # leads to the single node of interest, returns and / or saves the instances that exist at that node
 # ex. of path: split_path = [['CIT', 4, 0, True], ['PWGTP', 24, 1, False], ['RAC1P, 3', 1, True]]
+
+# JA: maybe we could -1 for left and 1 for right
+# the categorical part we have access to it via self.cat already
+# also, a list of tuples to preserve the internal order? [('CIT', 4, -1), ]
+
 def follow_path(split_path, data):
     for i in range(0, len(split_path)):
         # if feature is categorical:


### PR DESCRIPTION
Overall: we can now track the current path of the DT algorithm using self._current_path: due to recursion it goes back and forth accordingly (checked using iris data; hence, the print temporary print statements)

Added: 
(1) new da_info method that expect a t_weight (for target probability) line 228: @ruggieris, pls double-check; 
(2) new da_find_best_split_attribute that now only requires a t_weight rather than X_td and y_td; 
(3) updated best_split_of_all: it gets a dictionary of weights based on current path and based on the attribute c used for (2), it returns a t_weight. When t_weight is None, we default to standard information gain calculation

TODOs:
@ks555 under the method get_target_weights is where you can add the external information: use X_td as the input (now it can be anything)